### PR TITLE
Adding a related function to NtQueryInformationProcess

### DIFF
--- a/descriptions/ntqueryinformationprocess.md
+++ b/descriptions/ntqueryinformationprocess.md
@@ -31,6 +31,7 @@ For the list of supported info classes and required process access, see `PROCESS
  - [`GetProcessVersion`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getprocessversion)
  - [`GetProcessGroupAffinity`](https://learn.microsoft.com/en-us/windows/win32/api/processtopologyapi/nf-processtopologyapi-getprocessgroupaffinity)
  - [`GetPriorityClass`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getpriorityclass)
+ - [`GetLogicalDrives`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getlogicaldrives)
 
 # See also
  - `NtSetInformationProcess`

--- a/descriptions/processinfoclass.md
+++ b/descriptions/processinfoclass.md
@@ -318,6 +318,7 @@ When using `PROCESS_DEVICEMAP_INFORMATION_EX` to query information, the caller m
 
 ### Related Win32 API
  - [`DriveType`](https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-drivetype)
+ - [`GetLogicalDrives`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getlogicaldrives)
 
 ### See also
  - `OBJ_IGNORE_IMPERSONATED_DEVICEMAP`


### PR DESCRIPTION
Decompilation of GetLogicalDrives shows it uses NtQueryInformationProcess under the hood;


```
DWORD GetLogicalDrives
{
      int32_t buffer;
      NTSTATUS status = NtQueryInformationProcess(-1, 0x17, &buffer, 0x24, 0);
      
      if (status < STATUS_SUCCESS)
      {
          BaseSetLastNTError(status);
          return 0;
      }
      
      int32_t rax = buffer;
      
      if (rax != 0)
          return rax;
      
      RtlSetLastWin32Error(0);
      return buffer;
}
```
As such, I find it logical to add it to the "Related Win32 API" paragraph.