### PR TITLE
Add missing flag for NtGetNextThread

### DIFF
--- a/descriptions/ntgetnextprocess.md
+++ b/descriptions/ntgetnextprocess.md
@@ -1,12 +1,12 @@
 This function allows iterating over processes on the system without incurring any race conditions inherent to enumerating or opening processes by ID. Call this function repeatedly to open processes one by one.
 
 # Parameters
- - `ProcessHandle` - a handle to the previous process to continue enumeration from or `NULL` to restart enumeration.  The handle doesn't need to grant any particular access.
+ - `ProcessHandle` - a handle to the previous process to continue enumeration from or `NULL` to restart enumeration. The handle doesn't need to grant any particular access.
  - `DesiredAccess` - the process access mask expected on the opened handle.
  - `HandleAttributes` - flags that control the property of the handle, such as its inheritance (`OBJ_INHERIT`).
  - `Flags` - the bit mask that controls the operation. See below for known values.
  - `NewProcessHandle` - a pointer to a variable that receives a handle to the opened process.
-    
+
 # Known flags
  - `PROCESS_GET_NEXT_FLAGS_PREVIOUS_PROCESS` - reverses enumeration order by opening the previous process instead of the next one.
 

--- a/descriptions/ntgetnextthread.md
+++ b/descriptions/ntgetnextthread.md
@@ -5,14 +5,17 @@ This function allows iterating over threads in a process without incurring any r
  - `ThreadHandle` - a handle to the previous thread to continue enumeration from or `NULL` to restart enumeration. The handle doesn't need to grant any particular access.
  - `DesiredAccess` - the thread access mask expected on the opened handle.
  - `HandleAttributes` - flags that control the property of the handle, such as its inheritance (`OBJ_INHERIT`).
- - `Flags` - this parameter is unused and should be set to zero.
+ - `Flags` - the bit mask that controls the operation. See below for known values.
  - `NewThreadHandle` - a pointer to a variable that receives a handle to the opened thread.
+
+# Known flags
+ - `THREAD_GET_NEXT_FLAGS_PREVIOUS_THREAD` - reverses enumeration order by opening the previous thread instead of the next one.
 
 # Access masks
 For the list of thread-specific access masks, see `NtOpenThread`.
 
 # Notable return values
- - `STATUS_SUCCESS` - the function opened the next thread.
+ - `STATUS_SUCCESS` - the function opened the next/previous thread.
  - `STATUS_NO_MORE_ENTRIES` - the function failed because there are no more accessible threads to enumerate.
 
 # Remarks


### PR DESCRIPTION
@diversenok please review. I didn't test that the flag works, I relied on [the comment docs in phnt](https://github.com/winsiderss/systeminformer/blob/0c6dedee2b1bf4b4bda5c77a0a0506822f1ceb2c/phnt/include/ntpsapi.h#L2178).