### PR TITLE
Document kernel CI functions

### DIFF
--- a/descriptions/cichecksignedfile.md
+++ b/descriptions/cichecksignedfile.md
@@ -7,7 +7,7 @@ Verifies an Authenticode signature against a precomputed file hash. The caller i
  - `Signature` - a pointer to the raw `WIN_CERTIFICATE` bytes read from the PE security directory.
  - `SignatureSize` - the size of the signature blob, in bytes.
  - `PolicyInfo` - an optional pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the signer, including the certificate chain. The caller must release it with `CiFreePolicyInfo` when it is no longer needed.
- - `SigningTime` - an optional pointer that receives the counter-signed time of signing, when available.
+ - `SigningTime` - an optional pointer that receives the time of signing, when available.
  - `TimeStampPolicyInfo` - an optional pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the timestamping authority, with the same ownership and release rules as `PolicyInfo`.
 
 # Remarks

--- a/descriptions/cichecksignedfile.md
+++ b/descriptions/cichecksignedfile.md
@@ -1,0 +1,27 @@
+Verifies an Authenticode signature against a precomputed file hash. The caller is responsible for mapping the image, parsing its PE headers, locating the `WIN_CERTIFICATE` in the security directory, and computing the Authenticode digest.
+
+# Parameters
+ - `Hash` - a pointer to the Authenticode digest of the file being verified.
+ - `HashSize` - the size of the digest in bytes.
+ - `AlgorithmId` - the algorithm that was used to compute the digest, such as `CALG_SHA1` or `CALG_SHA_256`. The verifier iterates over the signatures embedded in the `WIN_CERTIFICATE` blob and selects the one whose digest algorithm matches this value.
+ - `Signature` - a pointer to the raw `WIN_CERTIFICATE` bytes read from the PE security directory.
+ - `SignatureSize` - the size of the signature blob, in bytes.
+ - `PolicyInfo` - an optional pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the signer, including the certificate chain and root authority. The caller must release it with `CiFreePolicyInfo` when it is no longer needed. Before calling, set the `Size` field to `sizeof(MINCRYPT_POLICY_INFO)`.
+ - `SigningTime` - an optional pointer that receives the counter-signed time of signing, when available.
+ - `TimeStampPolicyInfo` - an optional pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the timestamping authority, with the same ownership and release rules as `PolicyInfo`.
+
+# Return value
+Returns `STATUS_SUCCESS` when the digest is covered by a valid signature that chains to a trusted root. When verification fails, the function returns a failure `NTSTATUS` and, if `PolicyInfo` was provided, the `VerificationStatus` and `PolicyBits` fields indicate the specific reason (for example, `MINCRYPT_POLICY_NO_SIGNATURE`, `MINCRYPT_POLICY_BAD_SIGNATURE`, `MINCRYPT_POLICY_BAD_CHAIN`).
+
+# Remarks
+This function is exported from `ci.dll`. It is suitable for drivers that have already mapped and hashed the target image themselves, for instance to avoid remapping a file object that is already present in memory. `CiValidateFileObject` provides a higher-level alternative that performs the mapping and hashing for the caller but applies a stricter policy.
+
+Prior to Windows 7 SP1 with KB 2775511 (build 6.1.7601.18519), the function had a legacy prototype that only accepted SHA-1 hashes and did not take explicit size and algorithm parameters; the current prototype replaces it on all supported systems.
+
+For more details, see [Code Integrity in the Kernel: A Look Into ci.dll](https://www.cybereason.com/blog/code-integrity-in-the-kernel-a-look-into-cidll) by Liron Zuarets and Ido Moshe.
+
+# See also
+ - `CiFreePolicyInfo`
+ - `CiValidateFileObject`
+ - `CiVerifyHashInCatalog`
+ - `MINCRYPT_POLICY_INFO`

--- a/descriptions/cichecksignedfile.md
+++ b/descriptions/cichecksignedfile.md
@@ -6,17 +6,14 @@ Verifies an Authenticode signature against a precomputed file hash. The caller i
  - `AlgorithmId` - the algorithm that was used to compute the digest, such as `CALG_SHA1` or `CALG_SHA_256`. The verifier iterates over the signatures embedded in the `WIN_CERTIFICATE` blob and selects the one whose digest algorithm matches this value.
  - `Signature` - a pointer to the raw `WIN_CERTIFICATE` bytes read from the PE security directory.
  - `SignatureSize` - the size of the signature blob, in bytes.
- - `PolicyInfo` - an optional pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the signer, including the certificate chain and root authority. The caller must release it with `CiFreePolicyInfo` when it is no longer needed. Before calling, set the `Size` field to `sizeof(MINCRYPT_POLICY_INFO)`.
+ - `PolicyInfo` - an optional pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the signer, including the certificate chain. The caller must release it with `CiFreePolicyInfo` when it is no longer needed.
  - `SigningTime` - an optional pointer that receives the counter-signed time of signing, when available.
  - `TimeStampPolicyInfo` - an optional pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the timestamping authority, with the same ownership and release rules as `PolicyInfo`.
 
-# Return value
-Returns `STATUS_SUCCESS` when the digest is covered by a valid signature that chains to a trusted root. When verification fails, the function returns a failure `NTSTATUS` and, if `PolicyInfo` was provided, the `VerificationStatus` and `PolicyBits` fields indicate the specific reason (for example, `MINCRYPT_POLICY_NO_SIGNATURE`, `MINCRYPT_POLICY_BAD_SIGNATURE`, `MINCRYPT_POLICY_BAD_CHAIN`).
-
 # Remarks
-This function is exported from `ci.dll`. It is suitable for drivers that have already mapped and hashed the target image themselves, for instance to avoid remapping a file object that is already present in memory. `CiValidateFileObject` provides a higher-level alternative that performs the mapping and hashing for the caller but applies a stricter policy.
+This function is exported from `ci.dll`. It is suitable for drivers that have already mapped and hashed the target image themselves. `CiValidateFileObject` provides a higher-level alternative that performs the mapping and hashing for the caller but applies a stricter policy.
 
-Prior to Windows 7 SP1 with KB 2775511 (build 6.1.7601.18519), the function had a legacy prototype that only accepted SHA-1 hashes and did not take explicit size and algorithm parameters; the current prototype replaces it on all supported systems.
+Prior to build 6.1.7601.18519, the function had a legacy prototype that only accepted SHA-1 hashes and did not take explicit size and algorithm parameters.
 
 For more details, see [Code Integrity in the Kernel: A Look Into ci.dll](https://www.cybereason.com/blog/code-integrity-in-the-kernel-a-look-into-cidll) by Liron Zuarets and Ido Moshe.
 

--- a/descriptions/cichecksignedfile.md
+++ b/descriptions/cichecksignedfile.md
@@ -1,4 +1,4 @@
-Verifies an Authenticode signature against a precomputed file hash. The caller is responsible for mapping the image, parsing its PE headers, locating the `WIN_CERTIFICATE` in the security directory, and computing the Authenticode digest.
+For an input Authenticode file digest and an Authenticode signature, verifies that the digest is in the signature and that the signature validates. Optionally returns information about the signature. The caller is responsible for mapping the image, parsing its PE headers, locating the `WIN_CERTIFICATE` in the security directory, and computing the Authenticode digest.
 
 # Parameters
  - `Hash` - a pointer to the Authenticode digest of the file being verified.

--- a/descriptions/cifreepolicyinfo.md
+++ b/descriptions/cifreepolicyinfo.md
@@ -1,0 +1,17 @@
+Releases the resources referenced by a `MINCRYPT_POLICY_INFO` structure populated by one of the Code Integrity signature verification routines (such as `CiCheckSignedFile`, `CiVerifyHashInCatalog`, or `CiValidateFileObject`).
+
+# Parameters
+ - `PolicyInfo` - a pointer to the `MINCRYPT_POLICY_INFO` structure to release. The structure itself is owned by the caller; only the inner buffers (most notably the certificate chain information) are freed. The routine checks the structure for embedded allocations and does nothing if none are present, so it is safe to call on a zero-initialized structure or one whose verification failed.
+
+# Remarks
+Both the signer `MINCRYPT_POLICY_INFO` and the timestamping-authority `MINCRYPT_POLICY_INFO` populated by the verification APIs must be released by a separate call to this function. Failing to do so leaks the chain information buffer.
+
+This function is exported from `ci.dll` (the kernel-mode Code Integrity module). It is loaded dynamically at runtime by drivers that need to validate image signatures, typically through `MmGetSystemRoutineAddress` or an import table exposed by `ntoskrnl.exe` via `SeCodeIntegrityQueryInformation` and related infrastructure.
+
+For more details, see [Code Integrity in the Kernel: A Look Into ci.dll](https://www.cybereason.com/blog/code-integrity-in-the-kernel-a-look-into-cidll) by Liron Zuarets and Ido Moshe.
+
+# See also
+ - `MINCRYPT_POLICY_INFO`
+ - `CiCheckSignedFile`
+ - `CiVerifyHashInCatalog`
+ - `CiValidateFileObject`

--- a/descriptions/cifreepolicyinfo.md
+++ b/descriptions/cifreepolicyinfo.md
@@ -1,10 +1,12 @@
-Releases the resources referenced by a `MINCRYPT_POLICY_INFO` structure populated by one of the Code Integrity signature verification routines (such as `CiCheckSignedFile`, `CiVerifyHashInCatalog`, or `CiValidateFileObject`).
+Frees memory allocated by other Code Integrity signature verification functions and referenced from a `MINCRYPT_POLICY_INFO` structure.
 
 # Parameters
  - `PolicyInfo` - a pointer to the `MINCRYPT_POLICY_INFO` structure to release. The structure itself is owned by the caller; the inner certificate chain information buffer is freed. The routine is safe to call on a structure that was not populated (for example, when the preceding verification call failed).
 
 # Remarks
 This function is exported from `ci.dll`, the kernel-mode Code Integrity module.
+
+Per the FIPS 140-2 [Code Integrity Security Policy Document](https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp3644.pdf) (Microsoft, Windows 10 1809 / Windows Server 2019), the function "frees memory allocated by the `CiVerifyHashInCatalog`, `CiCheckSignedFile`, `CiFindPageHashesInCatalog`, and `CiFindPageHashesInSignedFile` functions". The same release is used for the `MINCRYPT_POLICY_INFO` structures produced by `CiValidateFileObject`, as documented in the Cybereason write-up below.
 
 For more details, see [Code Integrity in the Kernel: A Look Into ci.dll](https://www.cybereason.com/blog/code-integrity-in-the-kernel-a-look-into-cidll) by Liron Zuarets and Ido Moshe.
 

--- a/descriptions/cifreepolicyinfo.md
+++ b/descriptions/cifreepolicyinfo.md
@@ -1,12 +1,10 @@
 Releases the resources referenced by a `MINCRYPT_POLICY_INFO` structure populated by one of the Code Integrity signature verification routines (such as `CiCheckSignedFile`, `CiVerifyHashInCatalog`, or `CiValidateFileObject`).
 
 # Parameters
- - `PolicyInfo` - a pointer to the `MINCRYPT_POLICY_INFO` structure to release. The structure itself is owned by the caller; only the inner buffers (most notably the certificate chain information) are freed. The routine checks the structure for embedded allocations and does nothing if none are present, so it is safe to call on a zero-initialized structure or one whose verification failed.
+ - `PolicyInfo` - a pointer to the `MINCRYPT_POLICY_INFO` structure to release. The structure itself is owned by the caller; the inner certificate chain information buffer is freed. The routine is safe to call on a structure that was not populated (for example, when the preceding verification call failed).
 
 # Remarks
-Both the signer `MINCRYPT_POLICY_INFO` and the timestamping-authority `MINCRYPT_POLICY_INFO` populated by the verification APIs must be released by a separate call to this function. Failing to do so leaks the chain information buffer.
-
-This function is exported from `ci.dll` (the kernel-mode Code Integrity module). It is loaded dynamically at runtime by drivers that need to validate image signatures, typically through `MmGetSystemRoutineAddress` or an import table exposed by `ntoskrnl.exe` via `SeCodeIntegrityQueryInformation` and related infrastructure.
+This function is exported from `ci.dll`, the kernel-mode Code Integrity module.
 
 For more details, see [Code Integrity in the Kernel: A Look Into ci.dll](https://www.cybereason.com/blog/code-integrity-in-the-kernel-a-look-into-cidll) by Liron Zuarets and Ido Moshe.
 

--- a/descriptions/cigetcertpublishername.md
+++ b/descriptions/cigetcertpublishername.md
@@ -1,4 +1,4 @@
-Parses a DER-encoded X.509 certificate and returns the publisher name as a `UNICODE_STRING`. Typically used after a successful signature verification to obtain a human-readable signer name from the certificate chain returned in a `MINCRYPT_POLICY_INFO` structure.
+Parses a DER-encoded certificate and returns the publisher name as a `UNICODE_STRING`. Typically used after a successful signature verification to obtain a human-readable signer name from the certificate chain returned in a `MINCRYPT_POLICY_INFO` structure.
 
 # Parameters
  - `Certificate` - a pointer to a `CRYPT_DER_BLOB` that contains the DER-encoded certificate to parse. This is typically the `Certificate` field of one of the `MINCRYPT_CHAIN_ELEMENT` entries reached via `MINCRYPT_POLICY_INFO.ChainInfo.ChainElements` after a call to `CiCheckSignedFile`, `CiVerifyHashInCatalog`, or `CiValidateFileObject`.

--- a/descriptions/cigetcertpublishername.md
+++ b/descriptions/cigetcertpublishername.md
@@ -1,15 +1,14 @@
-Parses a DER-encoded X.509 certificate and extracts the publisher (subject common name) as a `UNICODE_STRING`. This is a convenience routine that callers can invoke after a successful signature verification to obtain a human-readable signer name from the certificate chain returned in a `MINCRYPT_POLICY_INFO` structure.
+Parses a DER-encoded X.509 certificate and returns the publisher name as a `UNICODE_STRING`. Typically used after a successful signature verification to obtain a human-readable signer name from the certificate chain returned in a `MINCRYPT_POLICY_INFO` structure.
 
 # Parameters
  - `Certificate` - a pointer to a `CRYPT_DER_BLOB` that contains the DER-encoded certificate to parse. This is typically the `Certificate` field of one of the `MINCRYPT_CHAIN_ELEMENT` entries reached via `MINCRYPT_POLICY_INFO.ChainInfo.ChainElements` after a call to `CiCheckSignedFile`, `CiVerifyHashInCatalog`, or `CiValidateFileObject`.
- - `AllocateRoutine` - a pointer to a caller-supplied allocator that the function invokes to obtain the backing storage for the returned string. The allocator is called with the number of bytes required and must return a pointer to memory that the caller will later release.
+ - `AllocateRoutine` - a pointer to a caller-supplied allocator that the function invokes to obtain the backing storage for the returned string.
  - `PublisherName` - a pointer to a `UNICODE_STRING` that receives the publisher name. The `Buffer` field is set to memory obtained from `AllocateRoutine` and becomes the caller's responsibility to free.
 
-# Return value
-Returns `STATUS_SUCCESS` on success. A failure `NTSTATUS` is returned if the certificate cannot be parsed, the subject common name is missing, or the allocator returns `NULL`.
-
 # Remarks
-This function is exported from `ci.dll`. The allocator is parameterized so that the routine can be used both from contexts that allocate from the non-paged pool (such as a driver reacting to a process-creation notification) and from contexts that prefer the paged pool; the function itself runs at `PASSIVE_LEVEL`.
+This function is exported from `ci.dll`.
+
+The exact portion of the certificate that is returned (for example, the subject common name versus the full subject) is not covered by any public documentation known to us.
 
 # See also
  - `CiValidateFileObject`

--- a/descriptions/cigetcertpublishername.md
+++ b/descriptions/cigetcertpublishername.md
@@ -1,0 +1,19 @@
+Parses a DER-encoded X.509 certificate and extracts the publisher (subject common name) as a `UNICODE_STRING`. This is a convenience routine that callers can invoke after a successful signature verification to obtain a human-readable signer name from the certificate chain returned in a `MINCRYPT_POLICY_INFO` structure.
+
+# Parameters
+ - `Certificate` - a pointer to a `CRYPT_DER_BLOB` that contains the DER-encoded certificate to parse. This is typically the `Certificate` field of one of the `MINCRYPT_CHAIN_ELEMENT` entries reached via `MINCRYPT_POLICY_INFO.ChainInfo.ChainElements` after a call to `CiCheckSignedFile`, `CiVerifyHashInCatalog`, or `CiValidateFileObject`.
+ - `AllocateRoutine` - a pointer to a caller-supplied allocator that the function invokes to obtain the backing storage for the returned string. The allocator is called with the number of bytes required and must return a pointer to memory that the caller will later release.
+ - `PublisherName` - a pointer to a `UNICODE_STRING` that receives the publisher name. The `Buffer` field is set to memory obtained from `AllocateRoutine` and becomes the caller's responsibility to free.
+
+# Return value
+Returns `STATUS_SUCCESS` on success. A failure `NTSTATUS` is returned if the certificate cannot be parsed, the subject common name is missing, or the allocator returns `NULL`.
+
+# Remarks
+This function is exported from `ci.dll`. The allocator is parameterized so that the routine can be used both from contexts that allocate from the non-paged pool (such as a driver reacting to a process-creation notification) and from contexts that prefer the paged pool; the function itself runs at `PASSIVE_LEVEL`.
+
+# See also
+ - `CiValidateFileObject`
+ - `CiCheckSignedFile`
+ - `CiVerifyHashInCatalog`
+ - `MINCRYPT_POLICY_INFO`
+ - `MINCRYPT_CHAIN_ELEMENT`

--- a/descriptions/cigetcertpublishername.md
+++ b/descriptions/cigetcertpublishername.md
@@ -10,6 +10,8 @@ This function is exported from `ci.dll`.
 
 The exact portion of the certificate that is returned (for example, the subject common name versus the full subject) is not covered by any public documentation known to us.
 
+A minimal working usage example, including a matching `AllocateRoutine` implementation that allocates from `NonPagedPoolNx`, is available in the [CiGetCertPublisherName](https://github.com/kkent030315/CiGetCertPublisherName) project by kkent030315.
+
 # See also
  - `CiValidateFileObject`
  - `CiCheckSignedFile`

--- a/descriptions/civalidatefileobject.md
+++ b/descriptions/civalidatefileobject.md
@@ -14,6 +14,10 @@ Verifies the signature of a file object and returns the policy info along with t
 # Remarks
 This function is exported from `ci.dll`. Unlike `CiCheckSignedFile`, it performs the mapping and hashing of the image itself. It also applies a stricter policy than `CiCheckSignedFile`, which means that some images that `CiCheckSignedFile` would accept can be rejected here.
 
+In practice, several contributors have reported that with a zero `PolicyFlags` the function rejects images signed with non-Microsoft root certificates unless test-signing mode is enabled, and that setting `CI_POLICY_ACCEPT_ANY_ROOT_CERTIFICATE` (`0x20`) in `PolicyFlags` makes verification succeed on production systems. Reproduced on Windows 10 builds 19041 and 19045; see [CiDllDemo issue #5](https://github.com/Ido-Moshe-Github/CiDllDemo/issues/5).
+
+In the same thread, contributors also report that the function returns `STATUS_INVALID_IMAGE_HASH` for PE images signed using ECDSA. An OSR forum analysis linked from the thread attributes this to a `MinCrypt_DisableEcdsa` routine invoked from `CipInitialize` during Code Integrity startup.
+
 For more details, see [Code Integrity in the Kernel: A Look Into ci.dll](https://www.cybereason.com/blog/code-integrity-in-the-kernel-a-look-into-cidll) by Liron Zuarets and Ido Moshe.
 
 # See also

--- a/descriptions/civalidatefileobject.md
+++ b/descriptions/civalidatefileobject.md
@@ -1,4 +1,4 @@
-Performs end-to-end Authenticode validation of a file given only a `FILE_OBJECT`. The routine maps the file into system address space, computes the Authenticode digest, and verifies the signature. The computed digest is returned to the caller through the `Thumbprint` output parameters.
+Verifies the signature of a file object and returns the policy info along with the timestamp and signing time. The routine maps the file into system address space, computes the Authenticode digest, and verifies the signature. The computed digest is returned to the caller through the `Thumbprint` output parameters.
 
 # Parameters
  - `FileObject` - a pointer to the `FILE_OBJECT` of the image to validate.

--- a/descriptions/civalidatefileobject.md
+++ b/descriptions/civalidatefileobject.md
@@ -1,0 +1,32 @@
+Performs end-to-end Authenticode validation of a file given only a `FILE_OBJECT`. The routine maps the file into system address space, parses its PE headers, computes the Authenticode digest, and then verifies the signature either from the embedded security directory or from a matching catalog entry. On success it optionally returns the digest it computed so that the caller does not have to read the file a second time.
+
+# Parameters
+ - `FileObject` - a pointer to the `FILE_OBJECT` of the image to validate. The caller must hold a reference on the object for the duration of the call.
+ - `PolicyFlags` - a bit mask of `CI_POLICY_*` flags controlling the verification policy (for example `CI_POLICY_CHECK_PROTECTED_PROCESS_EKU`, `CI_POLICY_FORCE_PROTECTED_PROCESS_POLICY`, `CI_POLICY_ACCEPT_ANY_ROOT_CERTIFICATE`). Flags outside `CI_POLICY_VALID_FLAGS` are rejected.
+ - `LevelCheck` - an `SE_SIGNING_LEVEL` value describing the minimum signing level that must be satisfied, for example `SE_SIGNING_LEVEL_WINDOWS` or `SE_SIGNING_LEVEL_ANTIMALWARE`.
+ - `PolicyInfo` - a pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the signer. The caller must release it with `CiFreePolicyInfo` when it is no longer needed. Before calling, set the `Size` field to `sizeof(MINCRYPT_POLICY_INFO)`.
+ - `TimeStampPolicyInfo` - a pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the timestamping authority, with the same ownership and release rules as `PolicyInfo`.
+ - `SigningTime` - a pointer that receives the counter-signed time of signing, when available.
+ - `Thumbprint` - a buffer that receives the Authenticode digest that was used to perform the verification. May be `NULL` together with a zero `*ThumbprintSize` if the digest is not needed.
+ - `ThumbprintSize` - on input, the size of the `Thumbprint` buffer in bytes; on output, the number of bytes written. On insufficient buffer, the function returns `STATUS_BUFFER_TOO_SMALL` with the required size written back.
+ - `ThumbprintAlgorithm` - a pointer that receives the algorithm identifier (an `ALG_ID` such as `CALG_SHA_256`) used to compute the returned digest.
+
+# Return value
+Returns `STATUS_SUCCESS` if the file is signed and the signature satisfies the requested policy. A failure `NTSTATUS` is returned otherwise; in that case the `VerificationStatus` and `PolicyBits` fields of the `MINCRYPT_POLICY_INFO` structures indicate the specific failure reason.
+
+# Remarks
+This function is exported from `ci.dll` and is the preferred entry point for drivers that do not need to pre-hash the image themselves. It applies a stricter policy than `CiCheckSignedFile`, which means that some images that `CiCheckSignedFile` would accept can be rejected here.
+
+Internally it tries the embedded Authenticode signature first and falls back to the catalog store (equivalent to `CiVerifyHashInCatalog`) when no embedded signature is present.
+
+Within the kernel, `CiValidateFileObject` is reached through the Code Integrity function table that `ntoskrnl.exe` populates during `CiInitialize`; it underlies the signing-level enforcement performed by `SeCodeIntegrity` routines when protected processes and signed drivers are loaded.
+
+For more details, see [Code Integrity in the Kernel: A Look Into ci.dll](https://www.cybereason.com/blog/code-integrity-in-the-kernel-a-look-into-cidll) by Liron Zuarets and Ido Moshe.
+
+# See also
+ - `CiCheckSignedFile`
+ - `CiVerifyHashInCatalog`
+ - `CiFreePolicyInfo`
+ - `CiGetCertPublisherName`
+ - `MINCRYPT_POLICY_INFO`
+ - `SE_SIGNING_LEVEL`

--- a/descriptions/civalidatefileobject.md
+++ b/descriptions/civalidatefileobject.md
@@ -1,25 +1,18 @@
-Performs end-to-end Authenticode validation of a file given only a `FILE_OBJECT`. The routine maps the file into system address space, parses its PE headers, computes the Authenticode digest, and then verifies the signature either from the embedded security directory or from a matching catalog entry. On success it optionally returns the digest it computed so that the caller does not have to read the file a second time.
+Performs end-to-end Authenticode validation of a file given only a `FILE_OBJECT`. The routine maps the file into system address space, computes the Authenticode digest, and verifies the signature. On success it optionally returns the digest it computed so that the caller does not have to hash the file a second time.
 
 # Parameters
- - `FileObject` - a pointer to the `FILE_OBJECT` of the image to validate. The caller must hold a reference on the object for the duration of the call.
- - `PolicyFlags` - a bit mask of `CI_POLICY_*` flags controlling the verification policy (for example `CI_POLICY_CHECK_PROTECTED_PROCESS_EKU`, `CI_POLICY_FORCE_PROTECTED_PROCESS_POLICY`, `CI_POLICY_ACCEPT_ANY_ROOT_CERTIFICATE`). Flags outside `CI_POLICY_VALID_FLAGS` are rejected.
- - `LevelCheck` - an `SE_SIGNING_LEVEL` value describing the minimum signing level that must be satisfied, for example `SE_SIGNING_LEVEL_WINDOWS` or `SE_SIGNING_LEVEL_ANTIMALWARE`.
- - `PolicyInfo` - a pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the signer. The caller must release it with `CiFreePolicyInfo` when it is no longer needed. Before calling, set the `Size` field to `sizeof(MINCRYPT_POLICY_INFO)`.
+ - `FileObject` - a pointer to the `FILE_OBJECT` of the image to validate.
+ - `PolicyFlags` - a bit mask of `CI_POLICY_*` flags controlling the verification policy (for example `CI_POLICY_CHECK_PROTECTED_PROCESS_EKU`, `CI_POLICY_FORCE_PROTECTED_PROCESS_POLICY`, `CI_POLICY_ACCEPT_ANY_ROOT_CERTIFICATE`).
+ - `LevelCheck` - an `SE_SIGNING_LEVEL` value passed to the verifier as part of the requested policy.
+ - `PolicyInfo` - a pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the signer. The caller must release it with `CiFreePolicyInfo` when it is no longer needed.
  - `TimeStampPolicyInfo` - a pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the timestamping authority, with the same ownership and release rules as `PolicyInfo`.
  - `SigningTime` - a pointer that receives the counter-signed time of signing, when available.
- - `Thumbprint` - a buffer that receives the Authenticode digest that was used to perform the verification. May be `NULL` together with a zero `*ThumbprintSize` if the digest is not needed.
- - `ThumbprintSize` - on input, the size of the `Thumbprint` buffer in bytes; on output, the number of bytes written. On insufficient buffer, the function returns `STATUS_BUFFER_TOO_SMALL` with the required size written back.
+ - `Thumbprint` - a buffer that receives the Authenticode digest that was used to perform the verification.
+ - `ThumbprintSize` - on input, the size of the `Thumbprint` buffer in bytes; on output, the number of bytes written.
  - `ThumbprintAlgorithm` - a pointer that receives the algorithm identifier (an `ALG_ID` such as `CALG_SHA_256`) used to compute the returned digest.
-
-# Return value
-Returns `STATUS_SUCCESS` if the file is signed and the signature satisfies the requested policy. A failure `NTSTATUS` is returned otherwise; in that case the `VerificationStatus` and `PolicyBits` fields of the `MINCRYPT_POLICY_INFO` structures indicate the specific failure reason.
 
 # Remarks
 This function is exported from `ci.dll` and is the preferred entry point for drivers that do not need to pre-hash the image themselves. It applies a stricter policy than `CiCheckSignedFile`, which means that some images that `CiCheckSignedFile` would accept can be rejected here.
-
-Internally it tries the embedded Authenticode signature first and falls back to the catalog store (equivalent to `CiVerifyHashInCatalog`) when no embedded signature is present.
-
-Within the kernel, `CiValidateFileObject` is reached through the Code Integrity function table that `ntoskrnl.exe` populates during `CiInitialize`; it underlies the signing-level enforcement performed by `SeCodeIntegrity` routines when protected processes and signed drivers are loaded.
 
 For more details, see [Code Integrity in the Kernel: A Look Into ci.dll](https://www.cybereason.com/blog/code-integrity-in-the-kernel-a-look-into-cidll) by Liron Zuarets and Ido Moshe.
 

--- a/descriptions/civalidatefileobject.md
+++ b/descriptions/civalidatefileobject.md
@@ -1,18 +1,18 @@
-Performs end-to-end Authenticode validation of a file given only a `FILE_OBJECT`. The routine maps the file into system address space, computes the Authenticode digest, and verifies the signature. On success it optionally returns the digest it computed so that the caller does not have to hash the file a second time.
+Performs end-to-end Authenticode validation of a file given only a `FILE_OBJECT`. The routine maps the file into system address space, computes the Authenticode digest, and verifies the signature. The computed digest is returned to the caller through the `Thumbprint` output parameters.
 
 # Parameters
  - `FileObject` - a pointer to the `FILE_OBJECT` of the image to validate.
  - `PolicyFlags` - a bit mask of `CI_POLICY_*` flags controlling the verification policy (for example `CI_POLICY_CHECK_PROTECTED_PROCESS_EKU`, `CI_POLICY_FORCE_PROTECTED_PROCESS_POLICY`, `CI_POLICY_ACCEPT_ANY_ROOT_CERTIFICATE`).
- - `LevelCheck` - an `SE_SIGNING_LEVEL` value passed to the verifier as part of the requested policy.
+ - `LevelCheck` - an `SE_SIGNING_LEVEL` value. The precise role of this parameter is not publicly documented; the name suggests it selects the signing level to enforce.
  - `PolicyInfo` - a pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the signer. The caller must release it with `CiFreePolicyInfo` when it is no longer needed.
  - `TimeStampPolicyInfo` - a pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the timestamping authority, with the same ownership and release rules as `PolicyInfo`.
- - `SigningTime` - a pointer that receives the counter-signed time of signing, when available.
+ - `SigningTime` - a pointer that receives the time of signing, when available.
  - `Thumbprint` - a buffer that receives the Authenticode digest that was used to perform the verification.
  - `ThumbprintSize` - on input, the size of the `Thumbprint` buffer in bytes; on output, the number of bytes written.
  - `ThumbprintAlgorithm` - a pointer that receives the algorithm identifier (an `ALG_ID` such as `CALG_SHA_256`) used to compute the returned digest.
 
 # Remarks
-This function is exported from `ci.dll` and is the preferred entry point for drivers that do not need to pre-hash the image themselves. It applies a stricter policy than `CiCheckSignedFile`, which means that some images that `CiCheckSignedFile` would accept can be rejected here.
+This function is exported from `ci.dll`. Unlike `CiCheckSignedFile`, it performs the mapping and hashing of the image itself. It also applies a stricter policy than `CiCheckSignedFile`, which means that some images that `CiCheckSignedFile` would accept can be rejected here.
 
 For more details, see [Code Integrity in the Kernel: A Look Into ci.dll](https://www.cybereason.com/blog/code-integrity-in-the-kernel-a-look-into-cidll) by Liron Zuarets and Ido Moshe.
 

--- a/descriptions/civerifyhashincatalog.md
+++ b/descriptions/civerifyhashincatalog.md
@@ -1,24 +1,23 @@
-Searches the installed signature catalogs for an entry that matches the supplied file hash and verifies the signature on the containing catalog. This is how Code Integrity validates files that are not signed inline, such as most Windows system binaries whose signatures live in `\SystemRoot\System32\CatRoot`.
+Searches the installed signature catalogs for an entry that matches the supplied file hash and verifies the signature on the containing catalog.
 
 # Parameters
  - `Hash` - a pointer to the file digest to look up in the catalogs.
  - `HashSize` - the size of the digest in bytes.
- - `AlgorithmId` - the algorithm used to compute the digest, such as `CALG_SHA1` or `CALG_SHA_256`. Only catalog entries indexed with the same algorithm are considered.
- - `ReloadCatalogs` - when non-zero, forces the Code Integrity subsystem to rescan the catalog store before performing the lookup. Use this to pick up catalogs that were installed after the module was first loaded.
- - `SecureProcess` - when non-zero, requests stricter policy that is appropriate for protected-process image loads; the exact semantics are a superset of the normal driver policy.
- - `AcceptRoots` - a bit mask of `MINCRYPT_POLICY_*_ROOT` values identifying which root authorities are acceptable for the catalog signer. Passing zero restricts verification to the default set for the current policy.
- - `PolicyInfo` - an optional pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the catalog signer, including the certificate chain and the matched root authority. The caller must release it with `CiFreePolicyInfo` when it is no longer needed. Before calling, set the `Size` field to `sizeof(MINCRYPT_POLICY_INFO)`.
+ - `AlgorithmId` - the algorithm used to compute the digest, such as `CALG_SHA1` or `CALG_SHA_256`.
+ - `ReloadCatalogs` - controls whether the Code Integrity subsystem rescans the catalog store before performing the lookup. The precise semantics of non-zero values are not publicly documented.
+ - `SecureProcess` - selects a stricter verification policy when non-zero. The precise semantics are not publicly documented.
+ - `AcceptRoots` - additional bits controlling which root authorities are acceptable for the catalog signer. The precise encoding is not publicly documented; typical values are drawn from the `MINCRYPT_POLICY_*_ROOT` flags.
+ - `PolicyInfo` - an optional pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the catalog signer. The caller must release it with `CiFreePolicyInfo` when it is no longer needed.
  - `CatalogName` - an optional pointer to a `UNICODE_STRING` that receives the full path of the catalog file that contained the matching hash. The buffer is allocated by the callee and must be released with `RtlFreeUnicodeString`.
  - `SigningTime` - an optional pointer that receives the counter-signed time of signing, when available.
  - `TimeStampPolicyInfo` - an optional pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the timestamping authority, with the same ownership and release rules as `PolicyInfo`.
 
-# Return value
-Returns `STATUS_SUCCESS` if a matching catalog entry is found and the catalog itself carries a valid signature that chains to an accepted root. A failure `NTSTATUS` is returned when no catalog contains the hash or when the catalog signature does not verify.
-
 # Remarks
-This function is exported from `ci.dll`. It is used together with `CiCheckSignedFile`: callers typically call `CiCheckSignedFile` first to look for an embedded signature and fall back to `CiVerifyHashInCatalog` when no embedded signature is present.
+This function is exported from `ci.dll`.
 
-Prior to Windows 7 SP1 with KB 2775511 (build 6.1.7601.18519), the function had a legacy prototype that only accepted SHA-1 hashes and did not take explicit size and algorithm parameters; the current prototype replaces it on all supported systems.
+Prior to build 6.1.7601.18519, the function had a legacy prototype that only accepted SHA-1 hashes and did not take explicit size and algorithm parameters.
+
+The meaning of the `ReloadCatalogs`, `SecureProcess`, and `AcceptRoots` parameters described above is inferred from their names; they are not covered by any public documentation known to us.
 
 # See also
  - `CiCheckSignedFile`

--- a/descriptions/civerifyhashincatalog.md
+++ b/descriptions/civerifyhashincatalog.md
@@ -1,4 +1,4 @@
-Searches the signature catalogs known to the Code Integrity subsystem for an entry that matches the supplied file hash and verifies the signature on the containing catalog.
+For an input Authenticode file digest, validates that the digest is contained within a verified system catalog. Optionally returns information about the catalog.
 
 # Parameters
  - `Hash` - a pointer to the file digest to look up in the catalogs.
@@ -13,7 +13,7 @@ Searches the signature catalogs known to the Code Integrity subsystem for an ent
  - `TimeStampPolicyInfo` - an optional pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the timestamping authority, with the same ownership and release rules as `PolicyInfo`.
 
 # Remarks
-This function is exported from `ci.dll`.
+This function is exported from `ci.dll`. The [pedigest](https://github.com/mihaly044/pedigest) project demonstrates using it as a fallback when a PE image does not carry an embedded signature that `CiCheckSignedFile` can verify.
 
 Prior to build 6.1.7601.18519, the function had a legacy prototype that only accepted SHA-1 hashes and did not take explicit size and algorithm parameters.
 

--- a/descriptions/civerifyhashincatalog.md
+++ b/descriptions/civerifyhashincatalog.md
@@ -1,4 +1,4 @@
-Searches the installed signature catalogs for an entry that matches the supplied file hash and verifies the signature on the containing catalog.
+Searches the signature catalogs known to the Code Integrity subsystem for an entry that matches the supplied file hash and verifies the signature on the containing catalog.
 
 # Parameters
  - `Hash` - a pointer to the file digest to look up in the catalogs.
@@ -8,8 +8,8 @@ Searches the installed signature catalogs for an entry that matches the supplied
  - `SecureProcess` - selects a stricter verification policy when non-zero. The precise semantics are not publicly documented.
  - `AcceptRoots` - additional bits controlling which root authorities are acceptable for the catalog signer. The precise encoding is not publicly documented; typical values are drawn from the `MINCRYPT_POLICY_*_ROOT` flags.
  - `PolicyInfo` - an optional pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the catalog signer. The caller must release it with `CiFreePolicyInfo` when it is no longer needed.
- - `CatalogName` - an optional pointer to a `UNICODE_STRING` that receives the full path of the catalog file that contained the matching hash. The buffer is allocated by the callee and must be released with `RtlFreeUnicodeString`.
- - `SigningTime` - an optional pointer that receives the counter-signed time of signing, when available.
+ - `CatalogName` - an optional pointer to a `UNICODE_STRING` that receives the name of the catalog file that contained the matching hash. The buffer is allocated by the callee and must be released with `RtlFreeUnicodeString`.
+ - `SigningTime` - an optional pointer that receives the time of signing, when available.
  - `TimeStampPolicyInfo` - an optional pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the timestamping authority, with the same ownership and release rules as `PolicyInfo`.
 
 # Remarks

--- a/descriptions/civerifyhashincatalog.md
+++ b/descriptions/civerifyhashincatalog.md
@@ -1,0 +1,27 @@
+Searches the installed signature catalogs for an entry that matches the supplied file hash and verifies the signature on the containing catalog. This is how Code Integrity validates files that are not signed inline, such as most Windows system binaries whose signatures live in `\SystemRoot\System32\CatRoot`.
+
+# Parameters
+ - `Hash` - a pointer to the file digest to look up in the catalogs.
+ - `HashSize` - the size of the digest in bytes.
+ - `AlgorithmId` - the algorithm used to compute the digest, such as `CALG_SHA1` or `CALG_SHA_256`. Only catalog entries indexed with the same algorithm are considered.
+ - `ReloadCatalogs` - when non-zero, forces the Code Integrity subsystem to rescan the catalog store before performing the lookup. Use this to pick up catalogs that were installed after the module was first loaded.
+ - `SecureProcess` - when non-zero, requests stricter policy that is appropriate for protected-process image loads; the exact semantics are a superset of the normal driver policy.
+ - `AcceptRoots` - a bit mask of `MINCRYPT_POLICY_*_ROOT` values identifying which root authorities are acceptable for the catalog signer. Passing zero restricts verification to the default set for the current policy.
+ - `PolicyInfo` - an optional pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the catalog signer, including the certificate chain and the matched root authority. The caller must release it with `CiFreePolicyInfo` when it is no longer needed. Before calling, set the `Size` field to `sizeof(MINCRYPT_POLICY_INFO)`.
+ - `CatalogName` - an optional pointer to a `UNICODE_STRING` that receives the full path of the catalog file that contained the matching hash. The buffer is allocated by the callee and must be released with `RtlFreeUnicodeString`.
+ - `SigningTime` - an optional pointer that receives the counter-signed time of signing, when available.
+ - `TimeStampPolicyInfo` - an optional pointer to a `MINCRYPT_POLICY_INFO` structure that receives information about the timestamping authority, with the same ownership and release rules as `PolicyInfo`.
+
+# Return value
+Returns `STATUS_SUCCESS` if a matching catalog entry is found and the catalog itself carries a valid signature that chains to an accepted root. A failure `NTSTATUS` is returned when no catalog contains the hash or when the catalog signature does not verify.
+
+# Remarks
+This function is exported from `ci.dll`. It is used together with `CiCheckSignedFile`: callers typically call `CiCheckSignedFile` first to look for an embedded signature and fall back to `CiVerifyHashInCatalog` when no embedded signature is present.
+
+Prior to Windows 7 SP1 with KB 2775511 (build 6.1.7601.18519), the function had a legacy prototype that only accepted SHA-1 hashes and did not take explicit size and algorithm parameters; the current prototype replaces it on all supported systems.
+
+# See also
+ - `CiCheckSignedFile`
+ - `CiValidateFileObject`
+ - `CiFreePolicyInfo`
+ - `MINCRYPT_POLICY_INFO`


### PR DESCRIPTION
Rendered:

* [`CiCheckSignedFile`](https://github.com/m417z/ntdoc/blob/document-kernel-ci/descriptions/cichecksignedfile.md)
* [`CiFreePolicyInfo`](https://github.com/m417z/ntdoc/blob/document-kernel-ci/descriptions/cifreepolicyinfo.md)
* [`CiGetCertPublisherName`](https://github.com/m417z/ntdoc/blob/document-kernel-ci/descriptions/cigetcertpublishername.md)
* [`CiValidateFileObject`](https://github.com/m417z/ntdoc/blob/document-kernel-ci/descriptions/civalidatefileobject.md)
* [`CiVerifyHashInCatalog`](https://github.com/m417z/ntdoc/blob/document-kernel-ci/descriptions/civerifyhashincatalog.md)

NtDoc:

* [`CiCheckSignedFile`](https://ntdoc.m417z.com/cichecksignedfile)
* [`CiFreePolicyInfo`](https://ntdoc.m417z.com/cifreepolicyinfo)
* [`CiGetCertPublisherName`](https://ntdoc.m417z.com/cigetcertpublishername)
* [`CiValidateFileObject`](https://ntdoc.m417z.com/civalidatefileobject)
* [`CiVerifyHashInCatalog`](https://ntdoc.m417z.com/civerifyhashincatalog)